### PR TITLE
Fix TinyURL API call

### DIFF
--- a/helpers/whatsapp.js
+++ b/helpers/whatsapp.js
@@ -4,7 +4,12 @@ const WHATSAPP_ACCESS_TOKEN = process.env.WHATSAPP_ACCESS_TOKEN;
 
 async function shortenUrl(longUrl) {
   try {
-    const response = await axios.post('https://tinyurl.com/api-create.php?url=' + encodeURIComponent(longUrl));
+    // TinyURL provides a simple GET API for shortening links
+    // Use GET instead of POST to avoid unnecessary request body
+    const response = await axios.get(
+      'https://tinyurl.com/api-create.php',
+      { params: { url: longUrl } }
+    );
     return response.data;
   } catch (error) {
     console.error('Error shortening URL:', error);


### PR DESCRIPTION
## Summary
- fix URL shortener to use a GET request when calling TinyURL

## Testing
- `node -c server.js`
- `node -c helpers/whatsapp.js`
- `node server.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6844bcf070608333812c5b731ac8d117