### PR TITLE
Fix MongoDB peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express-session": "^1.18.0",
     "connect-mongo": "^5.1.0",
     "mongoose": "^6.13.1",
-    "mongodb": "^4.7.0",
+    "mongodb": "^6.17.0",
     "cookie-parser": "^1.4.6",
     "express-rate-limit": "^7.4.0",
     "jsonwebtoken": "^9.0.2",
@@ -40,7 +40,7 @@
     "form-data": "^4.0.2"
   },
   "engines": {
-    "node": "16.x"
+    "node": "20.x"
   },
   "repository": {
     "url": "https://glitch.com/edit/#!/glitch-hello-node"

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -19,7 +19,7 @@ dependencies:
   helmet: 8.0.0
   isomorphic-fetch: 3.0.0
   jsonwebtoken: 9.0.2
-  mongodb: 4.17.2
+  mongodb: 6.17.0
   mongoose: 6.13.8
   multer: 1.4.4
 packages:
@@ -2219,7 +2219,7 @@ packages:
     dependencies:
       bson: 4.7.2
       kareem: 2.5.1
-      mongodb: 4.17.2
+      mongodb: 6.17.0
       mpath: 0.9.0
       mquery: 4.0.3
       ms: 2.1.3


### PR DESCRIPTION
## Summary
- bump mongodb dependency to satisfy connect-mongo
- target Node.js 20.x

## Testing
- `npm install --ignore-scripts --dry-run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mongodb)*

------
https://chatgpt.com/codex/tasks/task_e_6844be1602bc833387d48cd4ba22ecdf