### PR TITLE
Fix parsing of NPIK API response

### DIFF
--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -163,7 +163,18 @@ if (text && text.startsWith('\\')) {
 
     /* ② parse JSON if possible */
     let parsed = null;
-    try { parsed = JSON.parse(answer); } catch (_) {}
+    try {
+      parsed = JSON.parse(answer);
+      // NPIK responses wrap data in { success, data }
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'data' in parsed &&
+        Array.isArray(parsed.data)
+      ) {
+        parsed = parsed.data;
+      }
+    } catch (_) {}
 
     if (parsed) {
       /* ③ JSON → HTML table */


### PR DESCRIPTION
## Summary
- handle `success`/`data` wrapper returned by the NPIK API when parsing JSON

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6844c8f3de9883339355854276792f2d