### PR TITLE
Update AI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ npm start
 ```
 
 Make sure to provide a `.env` file with your database connection string and API keys.
+
+At minimum the following environment variable is required:
+
+- `MCP_API_KEY` – your API key for the AI service used by `helpers/ai.js`. The
+  server sends prompts to `https://getai-sooty.vercel.app/prompt`.

--- a/helpers/ai.js
+++ b/helpers/ai.js
@@ -1,9 +1,11 @@
 // helpers/ai.js
 const axios = require('axios');
 
-// Endpoint for the AI service. Previously this pointed to our MCP instance
-// but has been updated to use the new NPIK service.
-const MCP_URL = 'https://getai-npik.onrender.com/prompt';
+// Endpoint for the AI service.
+// The server expects POST requests with a JSON body containing { prompt } and
+// requires authentication via the `X-API-KEY` header.
+// Update this URL if the service location changes.
+const MCP_URL = 'https://getai-sooty.vercel.app/prompt';
 
 /**
  * Ask the MCP AI a natural-language database query.
@@ -14,7 +16,7 @@ async function askAI(message) {
   const apiKey = process.env.MCP_API_KEY;
   if (!apiKey) throw new Error('MCP_API_KEY missing');
 
-  // The NPIK API expects a JSON payload with a `prompt` field
+  // The service expects a JSON payload with a `prompt` field
   const payload = JSON.stringify({ prompt: message });
 
   // Use the API key via `X-API-KEY` header as required by the service


### PR DESCRIPTION
## Summary
- point `helpers/ai.js` to the new AI endpoint
- document `MCP_API_KEY` in README

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684591c6ce608333b7972953c289da5f