### PR TITLE
Improve AI error logging

### DIFF
--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -207,7 +207,11 @@ if (text && text.startsWith('\\')) {
       await sendMessage(from, answer);
     }
   } catch (err) {
-    console.error('[AI error]', err.response?.data || err.message);
+    const errData = err.response?.data;
+    const errMsg = Buffer.isBuffer(errData)
+      ? errData.toString('utf8')
+      : errData || err.message;
+    console.error('[AI error]', errMsg);
     await sendMessage(
       from,
       '⚠️  The AI service returned an error. Please try again later.'


### PR DESCRIPTION
## Summary
- improve handling when AI service returns a Buffer
- log readable string instead of the raw Buffer

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6845a312838083338ea3332a84c4f814