### PR TITLE
Fix QuickChart PDF endpoint

### DIFF
--- a/helpers/tablePdf.js
+++ b/helpers/tablePdf.js
@@ -47,7 +47,7 @@ async function jsonToHTMLTablePDF(data) {
   const html = `<!DOCTYPE html><html><body>${tableHtml}</body></html>`;
 
   const { data: pdfBuf } = await axios.post(
-    'https://quickchart.io/pdf',
+    'https://quickchart.io/html-to-pdf',
     { html },
     { responseType: 'arraybuffer' },
   );


### PR DESCRIPTION
## Summary
- update the HTML-to-PDF service URL used for generating reports

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684666f55cd48333aa2ed89b06e4bba2