### PR TITLE
Allow MCP URL override and silence mongoose warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ Make sure to provide a `.env` file with your database connection string and API 
 At minimum the following environment variable is required:
 
 - `MCP_API_KEY` – your API key for the AI service used by `helpers/ai.js`. The
-  server sends prompts to `https://getai-sooty.vercel.app/prompt`.
+ server sends prompts to `https://getai-sooty.vercel.app/prompt` by default.
+- `MCP_URL` *(optional)* – override the default AI endpoint if it changes.

--- a/helpers/ai.js
+++ b/helpers/ai.js
@@ -2,10 +2,10 @@
 const axios = require('axios');
 
 // Endpoint for the AI service.
-// The server expects POST requests with a JSON body containing { prompt } and
+// The server expects POST requests with a JSON body containing `{ prompt }` and
 // requires authentication via the `X-API-KEY` header.
-// Update this URL if the service location changes.
-const MCP_URL = 'https://getai-sooty.vercel.app/prompt';
+// The URL can be overridden via the `MCP_URL` environment variable.
+const MCP_URL = process.env.MCP_URL || 'https://getai-sooty.vercel.app/prompt';
 
 /**
  * Ask the MCP AI a natural-language database query.
@@ -22,15 +22,22 @@ async function askAI(message) {
   const payload = JSON.stringify({ prompt: message });
   
   // Use the API key via `X-API-KEY` header as required by the service
-  const { data } = await axios.post(MCP_URL, payload, {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-KEY': apiKey,
-    },
-  });
- console.log(data);
-  // assume text reply
-  return typeof data === 'string' ? data : JSON.stringify(data);
+  try {
+    const { data } = await axios.post(MCP_URL, payload, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-KEY': apiKey,
+      },
+    });
+    console.log(data);
+    // assume text reply
+    return typeof data === 'string' ? data : JSON.stringify(data);
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      throw new Error(`AI endpoint not found at ${MCP_URL}`);
+    }
+    throw err;
+  }
 }
 
 module.exports = { askAI };

--- a/server.js
+++ b/server.js
@@ -12,6 +12,9 @@ app.use(morgan('dev'));
 
 const port = process.env.PORT || 3000;
 
+// Silence Mongoose strictQuery warning for Mongoose >=7
+mongoose.set('strictQuery', false);
+
 // MongoDB Connection
 mongoose.connect(process.env.MONGODB_URI, {
   useNewUrlParser: true,


### PR DESCRIPTION
## Summary
- support `MCP_URL` environment variable in `helpers/ai.js`
- add helpful error if the AI endpoint returns 404
- silence mongoose strictQuery warning
- document `MCP_URL` in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846bd7c0ab88333ba02a67bf122b648