### PR TITLE
Add subscription_end field

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -33,6 +33,8 @@ const userSchema = new mongoose.Schema({
   },
   // When the current subscription became active
   subscriptionStart: { type: Date },
+  // When the current subscription expires
+  subscriptionEnd: { type: Date },
   // The date when the user registered
   registrationDate: {
     type: Date,

--- a/routes/payment.js
+++ b/routes/payment.js
@@ -68,8 +68,12 @@ router.post(
 
         const user = await User.findOne({ phoneNumber: phone });
         if (user) {
+          const now = new Date();
+          const end = new Date(now);
+          end.setFullYear(end.getFullYear() + 1);
           user.subscription = 'premium';
-          user.subscriptionStart = new Date();
+          user.subscriptionStart = now;
+          user.subscriptionEnd = end;
           await user.save();
 
           await Payment.create({


### PR DESCRIPTION
## Summary
- add a `subscriptionEnd` date to the user schema
- when payment webhook upgrades a user, set the expiry one year from now

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68473e6cf95c8333a7d6d9155a63791c