### PR TITLE
Improve Mongo connection handling

### DIFF
--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -13,6 +13,7 @@ const crypto = require('crypto');
 const redis = require('../services/redis');
 const analytics = require('../helpers/analytics');
 const { jobQueue } = require('../services/queue');
+const asyncHandler = require('../middleware/asyncHandler');
 
 const router = express.Router();
 const WHATSAPP_API_URL = 'https://graph.facebook.com/v20.0/110765315459068/messages';
@@ -150,7 +151,7 @@ router.get('/', (req, res) => {
 });
 
 // Webhook Handler
-router.post('/', async (req, res) => {
+router.post('/', asyncHandler(async (req, res) => {
   if (WHATSAPP_APP_SECRET) {
     const sig = req.headers['x-hub-signature-256'];
     const expected = 'sha256=' + crypto.createHmac('sha256', WHATSAPP_APP_SECRET)
@@ -336,6 +337,6 @@ case 'ai_reports':
 
   await setState('reg', phone, reg);
   return res.sendStatus(200);
-});
+}));
 
 module.exports = { router };

--- a/server.js
+++ b/server.js
@@ -31,13 +31,26 @@ const port = process.env.PORT || 3000;
 // Silence Mongoose strictQuery warning for Mongoose >=7
 mongoose.set('strictQuery', false);
 
-// MongoDB Connection
-mongoose.connect(process.env.MONGODB_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true
-})
-.then(() => console.log('✅ MongoDB connected'))
-.catch(err => console.error('❌ MongoDB connection error:', err));
+// Ensure Mongo URI is provided
+if (!process.env.MONGODB_URI) {
+  console.error('❌ MONGODB_URI not defined');
+  process.exit(1);
+}
+
+async function connectWithRetry(retries = 5) {
+  try {
+    await mongoose.connect(process.env.MONGODB_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('✅ MongoDB connected');
+  } catch (err) {
+    if (retries <= 0) throw err;
+    console.error('❌ MongoDB connection failed. Retrying...', err);
+    await new Promise(res => setTimeout(res, 5000));
+    return connectWithRetry(retries - 1);
+  }
+}
 
 // Mount payment routes (Webhook raw-body is handled in paymentRoutes)
 app.use('/', paymentRoutes);
@@ -60,4 +73,18 @@ if (process.env.SENTRY_DSN) {
 
 app.use(errorHandler);
 
-app.listen(port, () => console.log(`🚀 Server running on http://localhost:${port}`));
+async function startServer() {
+  await connectWithRetry();
+  app.listen(port, () =>
+    console.log(`🚀 Server running on http://localhost:${port}`)
+  );
+}
+
+startServer().catch(err => {
+  console.error('❌ Failed to start server:', err);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', err => {
+  console.error('Unhandled Rejection:', err);
+});


### PR DESCRIPTION
## Summary
- ensure MONGODB_URI is set and retry connecting to MongoDB
- start Express only after a successful connection
- log unhandled rejections
- wrap webhook handler with asyncHandler

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6847556b466083339ccb3a02175e5092