### PR TITLE
Fix express trust proxy for rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,9 @@ const errorHandler = require('./middleware/errorHandler');
 const Sentry = require('./services/sentry');
 
 const app = express();
+// Enable trust proxy if behind a reverse proxy to correctly process
+// the X-Forwarded-For header used by express-rate-limit
+app.set('trust proxy', true);
 app.use(morgan('dev'));
 if (process.env.SENTRY_DSN) {
   app.use(Sentry.Handlers.requestHandler());


### PR DESCRIPTION
## Summary
- configure Express to trust the proxy so express-rate-limit reads `X-Forwarded-For`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68489b6b1e3883338ae64dd29ce1e12c