### PR TITLE
Fix invalid ID crash

### DIFF
--- a/helpers/validators.js
+++ b/helpers/validators.js
@@ -1,3 +1,5 @@
+const mongoose = require('mongoose');
+
 function isValidName(name) {
   const regex = /^[a-zA-Z0-9 ]+$/;
   return (
@@ -40,10 +42,15 @@ function isValidDate(dateStr) {
   );
 }
 
+function isValidObjectId(id) {
+  return mongoose.Types.ObjectId.isValid(id);
+}
+
 module.exports = {
   isValidName,
   isValidAddress,
   isValidUnits,
   isValidTotalAmount,
   isValidDate,
+  isValidObjectId,
 };

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -291,6 +291,11 @@ if (text && text.startsWith('\\')) {
     const Unit = require('../models/Unit');
     switch (addUnitState.step) {
       case 'property': {
+        const { isValidObjectId } = require('../helpers/validators');
+        if (!isValidObjectId(text)) {
+          await sendMessage(from, '⚠️ Invalid property ID. Try again.');
+          break;
+        }
         const prop = await Property.findOne({ _id: text, ownerId: user._id });
         if (!prop) { await sendMessage(from, '⚠️ Invalid property ID. Try again.'); break; }
         addUnitState.data.property = prop._id;
@@ -350,6 +355,11 @@ if (text && text.startsWith('\\')) {
     const Tenant = require('../models/Tenant');
     switch (addTenantState.step) {
       case 'unit': {
+        const { isValidObjectId } = require('../helpers/validators');
+        if (!isValidObjectId(text)) {
+          await sendMessage(from, '⚠️ Invalid unit ID. Try again.');
+          break;
+        }
         const unit = await Unit.findById(text).populate('property');
         if (!unit || String(unit.property.ownerId) !== String(user._id)) {
           await sendMessage(from, '⚠️ Invalid unit ID. Try again.');


### PR DESCRIPTION
## Summary
- add `isValidObjectId` helper
- validate IDs when users type property or unit IDs via WhatsApp

## Testing
- `node -c routes/webhook.js`
- `node -c helpers/validators.js`


------
https://chatgpt.com/codex/tasks/task_e_684b3922140883338966f968e477ca65