### PR TITLE
Improve WhatsApp API handling

### DIFF
--- a/helpers/menuHelpers.js
+++ b/helpers/menuHelpers.js
@@ -1,10 +1,6 @@
 // routes/menuHelpers.js
-const axios = require('axios');
-const { sendMessage } = require('./whatsapp');
+const { sendMessage, api: whatsappApi } = require('./whatsapp');
 const chunkArray = require('./chunkArray');
-
-const WHATSAPP_API_URL = 'https://graph.facebook.com/v20.0/110765315459068/messages';
-const WHATSAPP_ACCESS_TOKEN = process.env.WHATSAPP_ACCESS_TOKEN;
 
 // Generic List Sender for multi-section lists (no header shown)
 async function sendList(to, headerText, sections, buttonLabel = 'Choose') {
@@ -19,9 +15,7 @@ async function sendList(to, headerText, sections, buttonLabel = 'Choose') {
       action: { button: buttonLabel, sections }
     }
   };
-  await axios.post(WHATSAPP_API_URL, payload, {
-    headers: { Authorization: `Bearer ${WHATSAPP_ACCESS_TOKEN}`, 'Content-Type': 'application/json' }
-  });
+  await whatsappApi.post('', payload);
 }
 
 // Generic Button Menu (no header shown). `headerText` is ignored
@@ -36,9 +30,7 @@ async function sendButtonMenu(to, headerText, bodyText, buttons) {
       action: { buttons }
     }
   };
-  await axios.post(WHATSAPP_API_URL, payload, {
-    headers: { Authorization: `Bearer ${WHATSAPP_ACCESS_TOKEN}`, 'Content-Type': 'application/json' }
-  });
+  await whatsappApi.post('', payload);
 }
 
 // Main Menu

--- a/workers/aiReportWorker.js
+++ b/workers/aiReportWorker.js
@@ -2,10 +2,7 @@ const { createWorker } = require('../services/queue');
 const { askAI } = require('../helpers/ai');
 const { jsonToHTMLTablePDF } = require('../helpers/tablePdf');
 const { uploadToWhatsApp } = require('../helpers/pdfHelpers');
-const axios = require('axios');
-
-const WHATSAPP_API_URL = 'https://graph.facebook.com/v20.0/110765315459068/messages';
-const WHATSAPP_ACCESS_TOKEN = process.env.WHATSAPP_ACCESS_TOKEN;
+const { api: whatsappApi } = require('../helpers/whatsapp');
 
 createWorker('ai-report', async job => {
   const { from, aiQuery } = job.data;
@@ -22,28 +19,18 @@ createWorker('ai-report', async job => {
     if (parsed) {
       const pdfBuf = await jsonToHTMLTablePDF(parsed);
       const mediaId = await uploadToWhatsApp(pdfBuf, 'report.pdf', 'application/pdf');
-      await axios.post(WHATSAPP_API_URL,
-        {
-          messaging_product: 'whatsapp',
-          to: from,
-          type: 'document',
-          document: { id: mediaId, filename: 'report.pdf' }
-        },
-        {
-          headers: { Authorization: `Bearer ${WHATSAPP_ACCESS_TOKEN}`, 'Content-Type': 'application/json' }
-        }
-      );
+      await whatsappApi.post('', {
+        messaging_product: 'whatsapp',
+        to: from,
+        type: 'document',
+        document: { id: mediaId, filename: 'report.pdf' }
+      });
     } else {
-      await axios.post(WHATSAPP_API_URL,
-        {
-          messaging_product: 'whatsapp',
-          to: from,
-          text: { body: answer }
-        },
-        {
-          headers: { Authorization: `Bearer ${WHATSAPP_ACCESS_TOKEN}`, 'Content-Type': 'application/json' }
-        }
-      );
+      await whatsappApi.post('', {
+        messaging_product: 'whatsapp',
+        to: from,
+        text: { body: answer }
+      });
     }
   } catch (err) {
     console.error('AI worker error', err);


### PR DESCRIPTION
## Summary
- reuse a persistent axios instance for WhatsApp API requests
- add automatic retries for WhatsApp calls
- update menu helpers and workers to use the shared instance
- wrap webhook route in async handler for better error reporting

## Testing
- `node --check helpers/whatsapp.js`
- `node --check helpers/menuHelpers.js`
- `node --check routes/webhook.js`
- `node --check workers/aiReportWorker.js`
- `npm ls` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684ba5034e18833387f2cb21b6707d8f