### PR TITLE
Add interactive newsletter buttons

### DIFF
--- a/helpers/menuHelpers.js
+++ b/helpers/menuHelpers.js
@@ -33,6 +33,15 @@ async function sendButtonMenu(to, headerText, bodyText, buttons) {
   await whatsappApi.post('', payload);
 }
 
+// Simple yes/no prompt using buttons
+async function sendYesNoPrompt(to, bodyText, prefix = 'newsletter') {
+  const buttons = [
+    { type: 'reply', reply: { id: `${prefix}_yes`, title: 'Yes' } },
+    { type: 'reply', reply: { id: `${prefix}_no`,  title: 'No'  } }
+  ];
+  await sendButtonMenu(to, '', bodyText, buttons);
+}
+
 // Main Menu
 async function sendMainMenu(to) {
   const { track } = require('./analytics');
@@ -170,5 +179,6 @@ module.exports = {
   promptAddUnit,
   promptAddTenant,
   promptRecordPayment,
-  sendPaymentHistory
+  sendPaymentHistory,
+  sendYesNoPrompt
 };

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -669,10 +669,13 @@ case 'ai_reports':
   } else if (selected && selected.startsWith('state_') && reg.step === 'state') {
     reg.data.state = selected.replace('state_', '');
     reg.step = 'newsletter';
-    await sendMessage(from, 'Receive newsletter? (yes/no)');
+    await menuHelpers.sendYesNoPrompt(from, 'Receive newsletter?');
 
-  } else if (reg.step === 'newsletter' && text) {
-    const ans = text.toLowerCase();
+  } else if (reg.step === 'newsletter' && (selected || text)) {
+    let ans;
+    if (selected === 'newsletter_yes') ans = 'yes';
+    else if (selected === 'newsletter_no') ans = 'no';
+    else if (text) ans = text.toLowerCase();
     if (!['yes', 'no'].includes(ans)) {
       return await sendMessage(from, '⚠️ Reply yes or no.');
     }


### PR DESCRIPTION
## Summary
- add reusable yes/no button helper
- ask for newsletter subscription via buttons

## Testing
- `npm test` *(fails: Missing script "test" because there are no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684bfa141d388333b73306c0b8f72a61