### PR TITLE
Add WhatsApp tester registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ At minimum the following environment variable is required:
 - `REDIS_URL` *(optional)* – connection string for Redis used to store session data.
 - `SENTRY_DSN` *(optional)* – enable Sentry error monitoring.
 - `WHATSAPP_APP_SECRET` *(optional)* – used to verify incoming WhatsApp webhook signatures.
+- `WHATSAPP_ACCESS_TOKEN` *(required)* – token for calling the WhatsApp Cloud API.
+- `WHATSAPP_BUSINESS_ID` *(required for registrations)* – business account ID used to add testers.

--- a/helpers/whatsapp.js
+++ b/helpers/whatsapp.js
@@ -4,6 +4,7 @@ const https = require('https');
 const WHATSAPP_API_URL =
   'https://graph.facebook.com/v20.0/110765315459068/messages';
 const WHATSAPP_ACCESS_TOKEN = process.env.WHATSAPP_ACCESS_TOKEN;
+const WHATSAPP_BUSINESS_ID = process.env.WHATSAPP_BUSINESS_ID;
 
 const agent = new https.Agent({ keepAlive: true });
 
@@ -93,10 +94,33 @@ async function sendImageOption(phoneNumber, type, entityId) {
   await sendRequest(buttonMenu);
 }
 
+// Add a phone number to the WhatsApp Business tester list so we can
+// send messages to it. The WHATSAPP_BUSINESS_ID environment variable
+// must be set along with the access token. This call is ignored if the
+// ID is not configured.
+async function addTester(phoneNumber) {
+  if (!WHATSAPP_BUSINESS_ID) return;
+  try {
+    await axios.post(
+      `https://graph.facebook.com/v20.0/${WHATSAPP_BUSINESS_ID}/testers`,
+      { phone: phoneNumber },
+      {
+        headers: { Authorization: `Bearer ${WHATSAPP_ACCESS_TOKEN}` },
+      }
+    );
+  } catch (err) {
+    console.error(
+      'WhatsApp tester add failed:',
+      err.response ? err.response.data : err
+    );
+  }
+}
+
 module.exports = {
   shortenUrl,
   sendMessage,
   sendImageMessage,
   sendImageOption,
+  addTester,
   api,
 };

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -6,7 +6,7 @@ require('../models/Tenant');
 const axios = require('axios');
 const User = require('../models/User');
 const menuHelpers = require('../helpers/menuHelpers');
-const { sendMessage, api: whatsappApi } = require('../helpers/whatsapp');
+const { sendMessage, api: whatsappApi, addTester } = require('../helpers/whatsapp');
 const { askAI }      = require('../helpers/ai');
 const { jsonToTableImage } = require('../helpers/tableImage');
 const { jsonToTableText }  = require('../helpers/tableText'); 
@@ -684,6 +684,8 @@ case 'ai_reports':
 
     // Save new user
     await new User(reg.data).save();
+    // Add phone to WABA tester list for messaging
+    await addTester(phone);
     await deleteState('reg', phone);
     await sendRegistrationSuccess(from);
   }


### PR DESCRIPTION
## Summary
- add new helper `addTester` to register phone numbers with the WhatsApp Business tester list
- call `addTester` when user completes registration
- document `WHATSAPP_ACCESS_TOKEN` and `WHATSAPP_BUSINESS_ID` environment variables

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./helpers/whatsapp'); console.log('helpers loaded')"` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_684ed301d8dc8333a0052bfe4705a665