### PR TITLE
Add WhatsApp tester helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ At minimum the following environment variable is required:
 - `REDIS_URL` *(optional)* – connection string for Redis used to store session data.
 - `SENTRY_DSN` *(optional)* – enable Sentry error monitoring.
 - `WHATSAPP_APP_SECRET` *(optional)* – used to verify incoming WhatsApp webhook signatures.
+- `WABA_ID` *(required for adding testers)* – WhatsApp Business Account ID used to automatically add new phone numbers as testers.

--- a/helpers/whatsapp.js
+++ b/helpers/whatsapp.js
@@ -93,10 +93,24 @@ async function sendImageOption(phoneNumber, type, entityId) {
   await sendRequest(buttonMenu);
 }
 
+async function addTester(phoneNumber) {
+  if (!process.env.WABA_ID) return;
+  try {
+    await axios.post(
+      `https://graph.facebook.com/v20.0/${process.env.WABA_ID}/testers`,
+      { phone: phoneNumber },
+      { headers: { Authorization: `Bearer ${WHATSAPP_ACCESS_TOKEN}` } }
+    );
+  } catch (err) {
+    console.error('Failed to add WhatsApp tester:', err.response?.data || err);
+  }
+}
+
 module.exports = {
   shortenUrl,
   sendMessage,
   sendImageMessage,
   sendImageOption,
+  addTester,
   api,
 };

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -6,7 +6,7 @@ require('../models/Tenant');
 const axios = require('axios');
 const User = require('../models/User');
 const menuHelpers = require('../helpers/menuHelpers');
-const { sendMessage, api: whatsappApi } = require('../helpers/whatsapp');
+const { sendMessage, api: whatsappApi, addTester } = require('../helpers/whatsapp');
 const { askAI }      = require('../helpers/ai');
 const { jsonToTableImage } = require('../helpers/tableImage');
 const { jsonToTableText }  = require('../helpers/tableText'); 
@@ -684,6 +684,7 @@ case 'ai_reports':
 
     // Save new user
     await new User(reg.data).save();
+    await addTester(from);
     await deleteState('reg', phone);
     await sendRegistrationSuccess(from);
   }


### PR DESCRIPTION
## Summary
- add `addTester` helper to WhatsApp module
- call `addTester` after user registration
- document new `WABA_ID` environment variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f2dbca54c8333b177af3086b9f19b